### PR TITLE
Fix Sign In after Sign Up

### DIFF
--- a/app/javascript/containers/signin/components/registrationForm.jsx
+++ b/app/javascript/containers/signin/components/registrationForm.jsx
@@ -15,10 +15,10 @@ export default function RegistrationForm({setErrorMessage}) {
     setFormData(newFormState);
   }
 
-  function submitRegistration() {
+  async function submitRegistration() {
 
     try{
-      ax.post('/users.json', {
+      await ax.post('/users.json', {
         user: {
           email: formData.email,
           password: formData.password,


### PR DESCRIPTION
# Problem

After successfully registering, the user was not being signed in, which is confusing and also bad.

# Solution

We were not using an async function for registration, and thus were reloading the page before registration completed. Async it.