### PR TITLE
Event and Lore Points

### DIFF
--- a/app/controllers/me_controller.rb
+++ b/app/controllers/me_controller.rb
@@ -13,6 +13,8 @@ class MeController < ApplicationController
               user_id: current_user.id,
               email: current_user.email,
               name: player.try(:name),
+              available_event_points: player.try(:available_event_points),
+              available_lore_points: player.try(:available_lore_points),
               signed_in: true
           }
         }

--- a/app/javascript/containers/player/components/profile.jsx
+++ b/app/javascript/containers/player/components/profile.jsx
@@ -6,7 +6,9 @@ import {Alert} from "reactstrap";
 
 export default function Profile() {
 
-  const [player, setPlayer] = useState({id: null, user_id: null, email: "", name: ""});
+  const [player, setPlayer] = useState({id: null,
+    user_id: null, email: "",
+    name: "", available_event_points: 0, available_lore_points: 0});
   const [editable, setEditable] = useState(false);
   const [errorMessage, setErrorMessage] = useState(null);
 
@@ -16,7 +18,9 @@ export default function Profile() {
       setPlayer({id: response.data.id,
         user_id: response.data.user_id,
         name: response.data.name,
-        email: response.data.email});
+        email: response.data.email,
+        available_event_points: response.data.available_event_points,
+        available_lore_points: response.data.available_lore_points});
     } catch (error) {
       console.log(error);
     }
@@ -32,7 +36,10 @@ export default function Profile() {
   function displayMode() {
 
     if (player.name && !editable) {
-      return <ShowProfile playerName={player.name} setEditable={setEditable} />
+      return <ShowProfile playerName={player.name}
+                          availableEventPoints={player.available_event_points}
+                          availableLorePoints={player.available_lore_points}
+                          setEditable={setEditable} />
     } else if (player.id && (!player.name || editable)) {
       return <EditProfile playerId={player.id}
                           playerName={player.name}

--- a/app/javascript/containers/player/components/showProfile.jsx
+++ b/app/javascript/containers/player/components/showProfile.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import {Button, Card, CardBody, CardText, CardTitle} from "reactstrap";
 
 
-export default function ShowProfile({playerName, setEditable}) {
+export default function ShowProfile({playerName, availableEventPoints, availableLorePoints, setEditable}) {
 
   function edit() {
     setEditable(true);
@@ -25,6 +25,14 @@ export default function ShowProfile({playerName, setEditable}) {
             <div class="row">
               <div className="col-sm-6">
                 Name: {playerName}
+              </div>
+            </div>
+            <div className="row">
+              <div className="col-sm-6">
+                Available Event Points: {availableEventPoints}
+              </div>
+              <div className="col-sm-6">
+                Available Lore Points: {availableLorePoints}
               </div>
             </div>
           </CardText>

--- a/db/migrate/20191127174817_add_event_and_lore_points.rb
+++ b/db/migrate/20191127174817_add_event_and_lore_points.rb
@@ -1,0 +1,6 @@
+class AddEventAndLorePoints < ActiveRecord::Migration[5.2]
+  def change
+    add_column :players, :available_event_points, :integer, null: false, default: 0
+    add_column :players, :available_lore_points, :integer, null: false, default: 0
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5,6 +5,7 @@ SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
+SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
 
@@ -47,7 +48,9 @@ CREATE TABLE public.players (
     user_id integer NOT NULL,
     name character varying,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    available_event_points integer DEFAULT 0 NOT NULL,
+    available_lore_points integer DEFAULT 0 NOT NULL
 );
 
 
@@ -189,6 +192,7 @@ SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
 ('20181204010605'),
-('20190112224240');
+('20190112224240'),
+('20191127174817');
 
 


### PR DESCRIPTION
# Problem

Players have two types of points they acquire and can spend: Event Points and Lore Points.

Both of these build up through events played or are granted by staff, and are then spent on things: event points on character experience points, and lore points on special things. Both of these are pools that rise and fall as gained and spent.

# Solution

Add two new fields to the `Player` model: `available_event_points` and `available_lore_points` and display these on the player profile. We won't be doing anything with them yet, but let's get them where they should be.