### PR TITLE
Fixing (hopefully) object rest spread error.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,7 +5,7 @@
 
   "plugins": [
     "@babel/plugin-syntax-dynamic-import",
-    "transform-object-rest-spread",
+    "@babel/plugin-proposal-object-rest-spread",
     "@babel/plugin-transform-runtime",
     ["@babel/plugin-proposal-class-properties", { "spec": true }]
   ]


### PR DESCRIPTION
Updating plugin for object spread. Why is javascript like this?